### PR TITLE
Fix: Change default tileserver port to 5005

### DIFF
--- a/modules/id.js
+++ b/modules/id.js
@@ -23,4 +23,4 @@ window.cancelIdleCallback = window.cancelIdleCallback ||
 
 import * as iD from './index';
 window.iD = iD;
-export default iD
+export default iD;

--- a/modules/ui/settings/custom_background.js
+++ b/modules/ui/settings/custom_background.js
@@ -9,7 +9,7 @@ export function uiSettingsCustomBackground(context) {
     var dispatch = d3_dispatch('change');
 
     function render(selection) {
-        var example = 'http://localhost:5000/styles/default/tiles/{zoom}/{x}/{y}';
+        var example = 'http://localhost:5005/styles/default/tiles/{zoom}/{x}/{y}';
         var _origSettings = {
             template: context.storage('background-custom-template') || example
         };


### PR DESCRIPTION
### Context
Custom tiles weren't loading in mapeo-desktop because the default tileserver port was 5000, but the tileserver is actually running on port 5005.
I worked on this with @okdistribute
Issue: https://github.com/digidem/mapeo-desktop/issues/261

### Changes
- Change the default tileserver port to 5005

cc @okdistribute @gmaclennan 