### PR TITLE
feat(Preset Editor): Add helper text and support long labels in preset editor

### DIFF
--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2589,7 +2589,7 @@ button.raw-tag-option svg.icon {
     width: 100%;
     overflow: hidden;
     display: none;
-    padding: 5px;
+    padding: 3px 5px 5px;
 }
 .tag-reference-body.expanded {
     padding-bottom: 5px;

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -5691,3 +5691,8 @@ li.hide + li.version .badge .tooltip .tooltip-arrow {
     width: 100px;
     color: #7092ff;
 }
+
+/* Custom overrides */
+.preset-editor a.hide-toggle-preset_fields {
+    display: none;
+}

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -1511,7 +1511,7 @@ button.preset-favorite-button.active .icon {
     display: flex;
     flex-flow: row nowrap;
     flex: 1 1 100%;
-    height: 30px;
+    min-height: 30px;
     position: relative;
     font-weight: bold;
     color: #333;

--- a/css/80_app.css
+++ b/css/80_app.css
@@ -2589,10 +2589,10 @@ button.raw-tag-option svg.icon {
     width: 100%;
     overflow: hidden;
     display: none;
-    padding-top: 10px;
+    padding: 5px;
 }
 .tag-reference-body.expanded {
-    padding-bottom: 10px;
+    padding-bottom: 5px;
     display: inline-block;
 }
 .tag-reference-description {

--- a/data/presets/schema/field.json
+++ b/data/presets/schema/field.json
@@ -108,6 +108,10 @@
             "description": "Placeholder text for this field",
             "type": "string"
         },
+        "helperText": {
+            "description": "Helper text for this field",
+            "type": "string"
+        },
         "strings": {
             "description": "Translatable strings options (combo fields)",
             "type": "object"

--- a/modules/presets/field.js
+++ b/modules/presets/field.js
@@ -30,6 +30,12 @@ export function presetField(id, field) {
     };
 
 
+    var helperText = field.helperText;
+    field.helperText = function() {
+        return field.t('helperText', {'default': helperText});
+    };
+
+
     field.originalTerms = (field.terms || []).join();
 
     field.terms = function() {

--- a/modules/presets/field.js
+++ b/modules/presets/field.js
@@ -19,8 +19,9 @@ export function presetField(id, field) {
     };
 
 
+    var label = field.label;
     field.label = function() {
-        return field.overrideLabel || field.t('label', {'default': id});
+        return field.overrideLabel || field.t('label', {'default': label || id});
     };
 
 

--- a/modules/ui/entity_editor.js
+++ b/modules/ui/entity_editor.js
@@ -13,7 +13,6 @@ import { uiQuickLinks } from './quick_links';
 import { uiRawMemberEditor } from './raw_member_editor';
 import { uiRawMembershipEditor } from './raw_membership_editor';
 import { uiRawTagEditor } from './raw_tag_editor';
-import { uiTagReference } from './tag_reference';
 import { uiPresetEditor } from './preset_editor';
 import { uiEntityIssues } from './entity_issues';
 import { uiTooltipHtml } from './tooltipHtml';
@@ -29,7 +28,6 @@ export function uiEntityEditor(context) {
     var _base;
     var _entityID;
     var _activePreset;
-    var _tagReference;
     var _presetFavorite;
 
     var entityIssues = uiEntityIssues(context);
@@ -137,15 +135,6 @@ export function uiEntityEditor(context) {
         if (_presetFavorite) {
             body.selectAll('.preset-list-button-wrap')
                 .call(_presetFavorite.button);
-        }
-
-        // update header
-        if (_tagReference) {
-            body.selectAll('.preset-list-button-wrap')
-                .call(_tagReference.button);
-
-            body.selectAll('.preset-list-item')
-                .call(_tagReference.body);
         }
 
         body.selectAll('.preset-reset')
@@ -351,8 +340,6 @@ export function uiEntityEditor(context) {
         if (!arguments.length) return _activePreset;
         if (val !== _activePreset) {
             _activePreset = val;
-            _tagReference = uiTagReference(_activePreset.reference(context.geometry(_entityID)), context)
-                .showing(false);
         }
         _presetFavorite = uiPresetFavoriteButton(_activePreset, context.geometry(_entityID), context);
         return entityEditor;

--- a/modules/ui/field.js
+++ b/modules/ui/field.js
@@ -186,7 +186,7 @@ export function uiField(context, presetField, entity, options) {
 
                 // instantiate tag reference
                 if (options.wrap && options.info) {
-                    reference = uiTagReference(d.placeholder(), context);
+                    reference = uiTagReference(d.helperText(), context);
                 }
 
                 selection
@@ -203,7 +203,7 @@ export function uiField(context, presetField, entity, options) {
                 // add tag reference components
                 if (reference) {
                     selection
-                        .call(reference.body)
+                        .call(reference.body);
                 }
 
                 d.impl.tags(_tags);

--- a/modules/ui/field.js
+++ b/modules/ui/field.js
@@ -186,15 +186,7 @@ export function uiField(context, presetField, entity, options) {
 
                 // instantiate tag reference
                 if (options.wrap && options.info) {
-                    var referenceKey = d.key;
-                    if (d.type === 'multiCombo') {   // lookup key without the trailing ':'
-                        referenceKey = referenceKey.replace(/:$/, '');
-                    }
-
-                    reference = uiTagReference(d.reference || { key: referenceKey }, context);
-                    if (_state === 'hover') {
-                        reference.showing(false);
-                    }
+                    reference = uiTagReference(d.placeholder(), context);
                 }
 
                 selection
@@ -212,8 +204,6 @@ export function uiField(context, presetField, entity, options) {
                 if (reference) {
                     selection
                         .call(reference.body)
-                        .select('.field-label')
-                        .call(reference.button);
                 }
 
                 d.impl.tags(_tags);

--- a/modules/ui/fields/combo.js
+++ b/modules/ui/fields/combo.js
@@ -348,7 +348,7 @@ export function uiFieldCombo(field, context) {
             .attr('type', 'text')
             .attr('id', 'preset-input-' + field.safeid)
             .call(utilNoAuto)
-            .call(initCombo, selection)
+            .call(initCombo, container)
             .merge(input);
 
         if (isNetwork && nominatim && _entity) {

--- a/modules/ui/fields/input.js
+++ b/modules/ui/fields/input.js
@@ -43,7 +43,7 @@ export function uiFieldText(field, context) {
             .append('input')
             .attr('type', field.type)
             .attr('id', fieldID)
-            .attr('placeholder', field.placeholder() || t('inspector.unknown'))
+            .attr('placeholder', field.placeholder() || '')
             .classed(field.type, true)
             .call(utilNoAuto)
             .merge(input);

--- a/modules/ui/fields/textarea.js
+++ b/modules/ui/fields/textarea.js
@@ -29,7 +29,7 @@ export function uiFieldTextarea(field) {
         input = input.enter()
             .append('textarea')
             .attr('id', 'preset-input-' + field.safeid)
-            .attr('placeholder', field.placeholder() || t('inspector.unknown'))
+            .attr('placeholder', field.placeholder() || '')
             .call(utilNoAuto)
             .on('input', change(true))
             .on('blur', change())

--- a/modules/ui/preset_editor.js
+++ b/modules/ui/preset_editor.js
@@ -26,6 +26,7 @@ export function uiPresetEditor(context) {
     function presetEditor(selection) {
         selection.call(uiDisclosure(context, 'preset_fields', true)
             .title(t('inspector.all_fields'))
+            .expanded(true)
             .content(render)
         );
     }

--- a/modules/ui/preset_list.js
+++ b/modules/ui/preset_list.js
@@ -403,9 +403,6 @@ export function uiPresetList(context) {
                 .append('div')
                 .attr('class', 'namepart')
                 .text(function(d) { return d; });
-
-            wrap.call(item.reference.button);
-            selection.call(item.reference.body);
         }
 
         item.choose = function() {
@@ -423,11 +420,9 @@ export function uiPresetList(context) {
 
         item.help = function() {
             d3_event.stopPropagation();
-            item.reference.toggle();
         };
 
         item.preset = preset;
-        item.reference = uiTagReference(preset.reference(context.geometry(_entityID)), context);
 
         return item;
     }

--- a/modules/ui/raw_tag_editor.js
+++ b/modules/ui/raw_tag_editor.js
@@ -6,7 +6,6 @@ import { services } from '../services';
 import { svgIcon } from '../svg/icon';
 import { uiCombobox } from './combobox';
 import { uiDisclosure } from './disclosure';
-import { uiTagReference } from './tag_reference';
 import { utilArrayDifference, utilGetSetValue, utilNoAuto, utilRebind, utilTagDiff } from '../util';
 
 
@@ -233,7 +232,7 @@ export function uiRawTagEditor(context) {
             .sort(function(a, b) { return a.index - b.index; });
 
         items
-            .each(function(d) {
+            .each(function() {
                 var row = d3_select(this);
                 var key = row.select('input.key');      // propagate bound data
                 var value = row.select('input.value');  // propagate bound data
@@ -241,24 +240,6 @@ export function uiRawTagEditor(context) {
                 if (_entityID && taginfo && _state !== 'hover') {
                     bindTypeahead(key, value);
                 }
-
-                var isRelation = (_entityID && context.entity(_entityID).type === 'relation');
-                var reference;
-
-                if (isRelation && d.key === 'type') {
-                    reference = uiTagReference({ rtype: d.value }, context);
-                } else {
-                    reference = uiTagReference({ key: d.key, value: d.value }, context);
-                }
-
-                if (_state === 'hover') {
-                    reference.showing(false);
-                }
-
-                row.select('.inner-wrap')      // propagate bound data
-                    .call(reference.button);
-
-                row.call(reference.body);
 
                 row.select('button.remove');   // propagate bound data
             });

--- a/modules/ui/tag_reference.js
+++ b/modules/ui/tag_reference.js
@@ -1,12 +1,6 @@
 import {
-    event as d3_event,
     select as d3_select
 } from 'd3-selection';
-
-import { t } from '../util/locale';
-import { services } from '../services';
-import { svgIcon } from '../svg/icon';
-
 
 // Pass `which` object of the form:
 // {
@@ -22,180 +16,33 @@ import { svgIcon } from '../svg/icon';
 //   qid: 'string'      // brand wikidata  (e.g. 'Q37158')
 // }
 //
-export function uiTagReference(what) {
-    var wikibase = what.qid ? services.wikidata : services.osmWikibase;
+export function uiTagReference(hint) {
     var tagReference = {};
 
-    var _button = d3_select(null);
     var _body = d3_select(null);
-    var _loaded;
     var _showing;
 
-
-    function load() {
-        if (!wikibase) return;
-
-        _button
-            .classed('tag-reference-loading', true);
-
-        wikibase.getDocs(what, gotDocs);
-    }
-
-
-    function gotDocs(err, docs) {
-        _body.html('');
-
-        if (!docs || !docs.title) {
-            _body
-                .append('p')
-                .attr('class', 'tag-reference-description')
-                .text(t('inspector.no_documentation_key'));
-            done();
-            return;
-        }
-
-        if (docs.imageURL) {
-            _body
-                .append('img')
-                .attr('class', 'tag-reference-wiki-image')
-                .attr('src', docs.imageURL)
-                .on('load', function() { done(); })
-                .on('error', function() { d3_select(this).remove(); done(); });
-        } else {
-            done();
-        }
-
-        _body
-            .append('p')
-            .attr('class', 'tag-reference-description')
-            .text(docs.description || t('inspector.no_documentation_key'))
-            .append('a')
-            .attr('class', 'tag-reference-edit')
-            .attr('target', '_blank')
-            .attr('tabindex', -1)
-            .attr('title', t('inspector.edit_reference'))
-            .attr('href', docs.editURL)
-            .call(svgIcon('#iD-icon-edit', 'inline'));
-
-        if (docs.wiki) {
-            _body
-              .append('a')
-              .attr('class', 'tag-reference-link')
-              .attr('target', '_blank')
-              .attr('tabindex', -1)
-              .attr('href', docs.wiki.url)
-              .call(svgIcon('#iD-icon-out-link', 'inline'))
-              .append('span')
-              .text(t(docs.wiki.text));
-        }
-
-        // Add link to info about "good changeset comments" - #2923
-        if (what.key === 'comment') {
-            _body
-                .append('a')
-                .attr('class', 'tag-reference-comment-link')
-                .attr('target', '_blank')
-                .attr('tabindex', -1)
-                .call(svgIcon('#iD-icon-out-link', 'inline'))
-                .attr('href', t('commit.about_changeset_comments_link'))
-                .append('span')
-                .text(t('commit.about_changeset_comments'));
-        }
-    }
-
-
-    function done() {
-        _loaded = true;
-
-        _button
-            .classed('tag-reference-loading', false);
-
-        _body
-            .classed('expanded', true)
-            .transition()
-            .duration(200)
-            .style('max-height', '200px')
-            .style('opacity', '1');
-
-        _showing = true;
-
-        _button.selectAll('svg.icon use').each(function() {
-            var iconUse = d3_select(this);
-            if (iconUse.attr('href') === '#iD-icon-info') {
-                iconUse.attr('href', '#iD-icon-info-filled');
-            }
-        });
-    }
-
-
-    function hide() {
-        _body
-            .transition()
-            .duration(200)
-            .style('max-height', '0px')
-            .style('opacity', '0')
-            .on('end', function () {
-                _body.classed('expanded', false);
-            });
-
-        _showing = false;
-
-        _button.selectAll('svg.icon use').each(function() {
-            var iconUse = d3_select(this);
-            if (iconUse.attr('href') === '#iD-icon-info-filled') {
-                iconUse.attr('href', '#iD-icon-info');
-            }
-        });
-
-    }
-
-
-    tagReference.button = function(selection, klass, iconName) {
-        _button = selection.selectAll('.tag-reference-button')
-            .data([0]);
-
-        _button = _button.enter()
-            .append('button')
-            .attr('class', 'tag-reference-button ' + klass)
-            .attr('title', t('icons.information'))
-            .attr('tabindex', -1)
-            .call(svgIcon('#iD-icon-' + (iconName || 'inspect')))
-            .merge(_button);
-
-        _button
-            .on('click', function () {
-                d3_event.stopPropagation();
-                d3_event.preventDefault();
-                this.blur();    // avoid keeping focus on the button - #4641
-                if (_showing) {
-                    hide();
-                } else if (_loaded) {
-                    done();
-                } else {
-                    load();
-                }
-            });
-    };
-
-
     tagReference.body = function(selection) {
-        var itemID = what.qid || what.rtype || (what.key + '-' + what.value);
+        var data = hint ? [hint] : [];
         _body = selection.selectAll('.tag-reference-body')
-            .data([itemID], function(d) { return d; });
+            .data(data, function(d) { return d; });
 
         _body.exit()
             .remove();
 
-        _body = _body.enter()
+        var enter = _body.enter()
             .append('div')
-            .attr('class', 'tag-reference-body')
-            .style('max-height', '0')
-            .style('opacity', '0')
-            .merge(_body);
+            .attr('class', 'tag-reference-body expanded')
+            .style('max-height', 'auto')
+            .style('opacity', '1');
 
-        if (_showing === false) {
-            hide();
-        }
+
+        enter
+            .append('p')
+            .attr('class', 'tag-reference-description')
+            .text(hint);
+
+        _body = enter.merge(_body);
     };
 
 

--- a/modules/ui/tools/search_add.js
+++ b/modules/ui/tools/search_add.js
@@ -459,7 +459,6 @@ export function uiToolSearchAdd(context) {
                 var reference = uiTagReference(d.preset.reference(d.geometry || d.geometries[0]), context);
 
                 var thisItem = d3_select(this);
-                thisItem.selectAll('.row').call(reference.button, 'accessory', 'info');
 
                 var subsection = thisItem
                     .append('div')


### PR DESCRIPTION
This change affects the appearance of the preset editor shown in the left-pane of iD Editor when a point/line/way is selected on the map.

It makes the following changes:

- [x] Remove support for tagInfo lookups (this only worked for OSM tags, which we do not generally use, and did not work offline.
- [x] Use the UI space for tagInfo for displaying a new field property `helperText` which shows additional information to help a user answer a question / fill in the field.
- [x] Remove the option to collapse the "All Fields" section of the preset editor. This was unintuitive and could result in users collapsing it by mistake and not being able to find the fields to fill in.
- [x] Allows labels for fields to span multiple lines
- [x] Removes the "Unknown" defult placeholder, and just displays an empty input box if no `placeholder` is defined for a field.
- [x] Uses `field.label` as the label if no translation is available (previously it defaulted to `field.id` if no translation was defined.
- [x] Ensure dropdowns are attached to the input field, not to the bottom of the helper text.